### PR TITLE
Remove reviewers from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     time: '04:00'
     timezone: Europe/Copenhagen
   open-pull-requests-limit: 10
-  reviewers:
-  - "spejder/odoo-client"
 - package-ecosystem: composer
   directory: "/"
   schedule:
@@ -19,5 +17,3 @@ updates:
   allow:
   - dependency-type: direct
   - dependency-type: indirect
-  reviewers:
-  - "spejder/odoo-client"


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/