### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,8 +1,13 @@
 on: pull_request
 name: Code style review
+permissions:
+  contents: read
 jobs:
   review_codestyle:
     name: Codestyle
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
@@ -22,6 +27,9 @@ jobs:
         vendor/bin/phpcs --report=checkstyle | ./reviewdog -f=checkstyle -name=PHPCS -reporter=github-pr-check
       env:
         REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: read
+      pull-requests: write
 
   static_code_analysis:
     name: Static Code Analysis


### PR DESCRIPTION
Potential fix for [https://github.com/spejder/odoo-client/security/code-scanning/3](https://github.com/spejder/odoo-client/security/code-scanning/3)

To fix the problem, add a `permissions` key to the workflow or to each job. The minimal requirement is to set `contents: read` at the workflow level, which will be inherited by all jobs unless they require more. For jobs like `review_codestyle` and `static_code_analysis` that use Reviewdog to post comments or checks, the `pull-requests: write` or `checks: write` permissions should be granted. For jobs like `markdownlint`, only `contents: read` is required. 

The best way to do this is to add a root-level `permissions:` block (just below `name:`) with the minimal permissions (e.g., `contents: read`), then add job-level `permissions:` blocks to `review_codestyle` and `static_code_analysis` to grant write access to `pull-requests` or `checks` as needed. Edits are all in `.github/workflows/pull-request.yml`, before and inside the `jobs:` and each job block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
